### PR TITLE
fix: detect single- and double-quoted targetNamespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 > XML validator using Apache Xerces-C++ compiled to WebAssembly. Features in-memory XSD caching for validation.
 
+## Playground
+
+Try the interactive [Browser playground for xerces-wasm](https://harshanacz.github.io/xerces-playground/) to run XML validation directly in your browser. The source code is available on [GitHub](https://github.com/harshanacz/xerces-playground).
+
 ## How it works
 
 Xerces-C++ validation inherently splits into two main phases. The initial XSD parsing and compilation takes time, while the validation is fast.

--- a/native/xerces_bridge.cpp
+++ b/native/xerces_bridge.cpp
@@ -158,15 +158,38 @@ static std::vector<DiagnosticEntry> runSyntaxPass(const std::string& xmlText) {
     return handler.entries;
 }
 
-// Extract targetNamespace value from XSD text (returns "" for no-namespace schemas)
+// Extract the targetNamespace value from XSD text (returns "" for no-namespace
+// schemas).  Accepts both single- and double-quoted attribute values and
+// tolerates whitespace around '=', e.g. targetNamespace = 'urn:x'.
 static std::string extractTargetNamespace(const std::string& xsdText) {
-    const std::string attr = "targetNamespace=\"";
-    size_t pos = xsdText.find(attr);
-    if (pos == std::string::npos) return "";
-    pos += attr.size();
-    size_t end = xsdText.find('"', pos);
-    if (end == std::string::npos) return "";
-    return xsdText.substr(pos, end - pos);
+    auto isXmlSpace = [](char c) {
+        return c == ' ' || c == '\t' || c == '\n' || c == '\r';
+    };
+
+    const std::string attr = "targetNamespace";
+    for (size_t pos = xsdText.find(attr); pos != std::string::npos;
+         pos = xsdText.find(attr, pos + attr.size())) {
+        // Require a standalone attribute name: the char before must be
+        // whitespace (or the match starts the text) so we don't match a
+        // substring like "fooTargetNamespace".
+        if (pos != 0 && !isXmlSpace(xsdText[pos - 1])) continue;
+
+        size_t cur = pos + attr.size();
+        while (cur < xsdText.size() && isXmlSpace(xsdText[cur])) cur++;
+        if (cur >= xsdText.size() || xsdText[cur] != '=') continue;
+        cur++;  // past '='
+        while (cur < xsdText.size() && isXmlSpace(xsdText[cur])) cur++;
+        if (cur >= xsdText.size()) continue;
+
+        const char quote = xsdText[cur];
+        if (quote != '"' && quote != '\'') continue;
+        cur++;  // past opening quote
+
+        const size_t end = xsdText.find(quote, cur);
+        if (end == std::string::npos) return "";
+        return xsdText.substr(cur, end - cur);
+    }
+    return "";
 }
 
 // Pass 2 — schema validation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xerces-wasm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Fast XML schema validator using Apache Xerces-C++ compiled to WebAssembly with in-memory XSD caching",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tests/namespace-detection.test.ts
+++ b/tests/namespace-detection.test.ts
@@ -1,0 +1,57 @@
+import { createProjectValidator } from "../src/index";
+
+// A schema that declares targetNamespace using SINGLE quotes. This exercises
+// the quote-agnostic auto-detection path: with targetNamespace omitted from the
+// options, the bridge must read it straight from the XSD text.
+const SINGLE_QUOTED_XSD = `<?xml version='1.0' encoding='UTF-8'?>
+<xs:schema xmlns:xs='http://www.w3.org/2001/XMLSchema'
+           targetNamespace='http://example.com/ns'
+           xmlns='http://example.com/ns'
+           elementFormDefault='qualified'>
+  <xs:element name='note'>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name='to' type='xs:string'/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+`;
+
+describe("targetNamespace auto-detection", () => {
+  it("detects a single-quoted targetNamespace and validates a namespaced document", async () => {
+    const validator = await createProjectValidator({
+      entry: "note.xsd",
+      files: { "note.xsd": SINGLE_QUOTED_XSD },
+      // targetNamespace intentionally omitted → forces auto-detection
+    });
+    try {
+      const xml = `<note xmlns='http://example.com/ns'><to>Bob</to></note>`;
+      const res = await validator.validate(xml);
+
+      expect(res.parseErrors).toEqual([]);
+      expect(res.schemaErrors).toEqual([]);
+      expect(res.valid).toBe(true);
+    } finally {
+      validator.destroy();
+    }
+  });
+
+  it("still enforces the schema for a single-quoted-namespace XSD", async () => {
+    const validator = await createProjectValidator({
+      entry: "note.xsd",
+      files: { "note.xsd": SINGLE_QUOTED_XSD },
+    });
+    try {
+      // Missing the required <to> child — must be reported as a schema error,
+      // proving the schema is actually engaged (not silently treated as no-namespace).
+      const xml = `<note xmlns='http://example.com/ns'></note>`;
+      const res = await validator.validate(xml);
+
+      expect(res.valid).toBe(false);
+      expect(res.schemaErrors.length).toBeGreaterThan(0);
+    } finally {
+      validator.destroy();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`targetNamespace` auto-detection only matched the double-quoted form
(`targetNamespace="..."`), so schemas that declare it with single quotes
(`targetNamespace='...'`) fell back to no-namespace validation and reported
spurious errors. XML permits either quote character for attribute values, so
single-quoted schemas are valid and should work.

This makes the scan quote-agnostic and tolerant of whitespace around `=`, with a
word-boundary guard so it won't match substrings like `fooTargetNamespace`.

## Changes

- **`native/xerces_bridge.cpp`** — rewrite `extractTargetNamespace` to accept both
  `'` and `"` quoting and optional whitespace around `=`.
- **`tests/namespace-detection.test.ts`** — new tests: a single-quoted-namespace
  schema validates a matching document, and a missing required child is still
  flagged (proving the schema is actually engaged, not silently treated as
  no-namespace).

## Testing

- `npm run build:wasm` — bridge recompiled (Xerces lib cached)
- `npm test` — **9 passed**, 3 suites

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a browser-based Playground for running XML validation, with a link to its source code.
* **Bug Fixes**
  * Improved automatic detection of XSD `targetNamespace` values.
  * Namespace detection now supports single or double quotes and flexible spacing.
  * Validation now correctly applies schemas when namespaces are detected automatically.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->